### PR TITLE
+Commit fixes (Also UserCode changes)

### DIFF
--- a/Anabi.Domain.Core/Asset/AddAssetAddressHandler.cs
+++ b/Anabi.Domain.Core/Asset/AddAssetAddressHandler.cs
@@ -28,6 +28,9 @@ namespace Anabi.Domain.Asset
                 AddedDate = DateTime.Now
             }; 
 
+            var asset = await context.Assets.FindAsync(message.AssetId);
+            asset.Address = address;
+
             context.Addresses.Add(address);
             await context.SaveChangesAsync(cancellationToken);
 

--- a/Anabi.Domain.Core/Asset/Commands/AddAssetAddress.cs
+++ b/Anabi.Domain.Core/Asset/Commands/AddAssetAddress.cs
@@ -21,6 +21,11 @@ namespace Anabi.Domain.Asset.Commands
         {
             AssetId = assetId;
         }
+        
+        public AddAssetAddress()
+        {
+            
+        }
     }
 
 

--- a/Anabi.Domain.Core/Asset/Commands/AddAssetAddressRequest.cs
+++ b/Anabi.Domain.Core/Asset/Commands/AddAssetAddressRequest.cs
@@ -1,7 +1,7 @@
 using Anabi.DataAccess.Ef.DbModels;
-public class AddAssetAddressRequest : BaseEntity
+public class AddAssetAddressRequest
     {
-         public int CountyId { get; set; }
+        public int CountyId { get; set; }
 
         public string Street { get; set; }
 

--- a/Anabi.Domain.Core/BaseHandler.cs
+++ b/Anabi.Domain.Core/BaseHandler.cs
@@ -23,16 +23,25 @@ namespace Anabi.Domain
 
         protected string UserCode()
         {
-            var p = principal as ClaimsPrincipal;
-            if (p == null)
+            try
             {
-                //TODO return error at a later time
-                return "admin";
-            }
+               var p = principal as ClaimsPrincipal;
+                if (p == null)
+                {
+                    //TODO return error at a later time
+                    return "admin";
+                }
 
-            return p.Claims?.SingleOrDefault(c =>
-                    c.Type == ClaimTypes.NameIdentifier)
-                .Value;
+                return p.Claims?.SingleOrDefault(c =>
+                        c.Type == ClaimTypes.NameIdentifier)
+                    .Value; 
+                }
+            catch (System.Exception)
+            {
+                
+                 return "admin";
+            }
+            
         }
     }
 }

--- a/Anabi/Features/Assets/AssetsController.cs
+++ b/Anabi/Features/Assets/AssetsController.cs
@@ -10,6 +10,7 @@ using Anabi.Domain.Asset.Commands;
 using Anabi.Middleware;
 using Anabi.Common.ViewModels;
 using Anabi.Domain.Core.Asset.Commands;
+using AutoMapper;
 
 namespace Anabi.Features.Assets
 {
@@ -19,9 +20,12 @@ namespace Anabi.Features.Assets
     public class AssetsController : BaseController
     {
         private readonly IMediator mediator;
-        public AssetsController(IMediator _mediator)
+        private readonly IMapper mapper;
+
+        public AssetsController(IMediator _mediator, IMapper _mapper)
         {
             mediator = _mediator;
+            mapper = _mapper;
         }
 
         /// <summary>
@@ -185,7 +189,7 @@ namespace Anabi.Features.Assets
         [HttpPost("{assetId}/address")]
         public async Task<IActionResult> AddAssetAddress(int assetId, [FromBody] AddAssetAddressRequest request)
         {
-            var message = AutoMapper.Mapper.Map<AddAssetAddressRequest, AddAssetAddress>(request);
+            var message = mapper.Map<AddAssetAddressRequest, AddAssetAddress>(request);
             message.AssetId = assetId;
 
             var model = await mediator.Send(message);


### PR DESCRIPTION
+Assets now correctly display their addressId in the database (code added in Anabi.Domain.Core/Asset/AddAddressHandler)
+Added empty constructor in Anabi.Domain.Core/Asset/Commands/AddAssetAddress.cs for the mapper to use
+Anabi.Domain.Core/Asset/Commands/AddAssetAddressRequest.cs no longer inherits from BaseEntity
+Anabi.Domain.Core/BaseHandler.cs UserCode() now only displays admin until UnhandledException is fixed.
+Anabi/Features/Assets/AssetsController.cs fixed Mapper usage.