### PR TITLE
Normalise migrations

### DIFF
--- a/Anabi.DataAccess.Ef/Migrations/20190330144946_NormaliseMigrations.Designer.cs
+++ b/Anabi.DataAccess.Ef/Migrations/20190330144946_NormaliseMigrations.Designer.cs
@@ -4,14 +4,16 @@ using Anabi.DataAccess.Ef;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Anabi.DataAccess.Ef.Migrations
 {
     [DbContext(typeof(AnabiContext))]
-    partial class AnabiContextModelSnapshot : ModelSnapshot
+    [Migration("20190330144946_NormaliseMigrations")]
+    partial class NormaliseMigrations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Anabi.DataAccess.Ef/Migrations/20190330144946_NormaliseMigrations.cs
+++ b/Anabi.DataAccess.Ef/Migrations/20190330144946_NormaliseMigrations.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Anabi.DataAccess.Ef.Migrations
+{
+    public partial class NormaliseMigrations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserCodeLastChange",
+                table: "Addresses",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserCodeAdd",
+                table: "Addresses",
+                maxLength: 20,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Stair",
+                table: "Addresses",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 5,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FlatNo",
+                table: "Addresses",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 5,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Building",
+                table: "Addresses",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 10,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserCodeLastChange",
+                table: "Addresses",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 20,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserCodeAdd",
+                table: "Addresses",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 20);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Stair",
+                table: "Addresses",
+                maxLength: 5,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FlatNo",
+                table: "Addresses",
+                maxLength: 5,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Building",
+                table: "Addresses",
+                maxLength: 10,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Dintr-un motiv sau altul, fără nici o modificare în model, pare că are niște migrări lipsă.

Ran
```
dotnet ef migrations \
  add NormaliseMigrations \
  --context AnabiContext \
  -p Anabi.DataAccess.Ef/Anabi.DataAccess.Ef.csproj \
  -s Anabi/Anabi.csproj
```
