### PR TITLE
Add _build_ step for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
 
 jobs:
   include:
-    - stage: test
+    - stage: build image
       script:
-        - echo "Tests should go here"
+        - docker build .
 
     - stage: deploy
       name: "Build and publish image to registry"


### PR DESCRIPTION
If building the image fails, then it shouldn't be merged.
Running unit tests, etc. should probably go in the `Dockerfile`,
anyway.

### Description of the Change

Adds an actual build step for Travis-CI.